### PR TITLE
return http headers as a map

### DIFF
--- a/include/via/http/headers.hpp
+++ b/include/via/http/headers.hpp
@@ -310,6 +310,10 @@ namespace via
       bool valid() const NOEXCEPT
       { return valid_; }
 
+      // @return headers as a map
+      const std::unordered_map<std::string, std::string>& fields() const
+      { return fields_; }
+      
       /// Output the message_headers as a string.
       /// Note: it is NOT terminated with an extra CRLF tso that it parses
       /// the are_headers_split function.

--- a/include/via/http_client.hpp
+++ b/include/via/http_client.hpp
@@ -188,12 +188,11 @@ namespace via
       if (connection_->connected())
       {
         connection_->set_connected(false);
-
-        if (disconnected_handler_)
-          disconnected_handler_();
-
         connection_->close();
       }
+
+      if (disconnected_handler_)
+        disconnected_handler_();
 
       // attempt to reconnect in period_ miliseconds
       if (period_ > 0)


### PR DESCRIPTION
This PR allows to retrieve the request headers like this:

```c++
static void wwwResponseCallback(void* pHttpServer, HttpResponse& response) {

std::unordered_map<std::string, std::string> requestHeaders = response.GetRequest().headers().fields();
.....

}
```

Among the other things it's useful for logging.

Thanks
